### PR TITLE
legacy link fix. 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,7 @@ nav:
     - Mailing List: community/listserv.md
   - About Us:
     - about/index.md
-    - Legacy Site Archive: archive/index.html
+    - Legacy Site Archive: https://sea.ucar.edu/
 
 # ------------------------------------
 # -- configuration - themes


### PR DESCRIPTION
This fixes `mkdocs build --stric` issue. 