### PR TITLE
Revert "Redirecting conference paths to iss paths"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,11 +168,6 @@ plugins:
   - blog:
       blog_dir: .
 
-  - redirects:
-      redirect_maps:
-        'conference/index.md': 'iss/index.md'
-        'conference/2024.md': 'iss/2024.md'
-
 # ------------------------------------
 # -- configuration - extras
 # ------------------------------------


### PR DESCRIPTION
Reverts UCAR-SEA/sea-website#4

It seems like something went wrong with #4, but none of the tests and local build caught it. I am merging this in and waiting for @vanderwb's review on #4 to better understand why it brought down the whole page. 