### PR TITLE
Redirecting conference paths to iss paths

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,6 +168,11 @@ plugins:
   - blog:
       blog_dir: .
 
+  - redirects:
+      redirect_maps:
+        'conference/index.md': 'iss/index.md'
+        'conference/2024.md': 'iss/2024.md'
+
 # ------------------------------------
 # -- configuration - extras
 # ------------------------------------


### PR DESCRIPTION
This is the same as PR #4 and solves the issue of redirecting /conference to /iss. 

So: 
 https://sea.ucar.edu/conference/ will be forwarded to https://sea.ucar.edu/iss/


This was reverted (in #5) because the `CNAME` forwarding was not working after merging #4. But that issue got fixed by changing the settings on the repository. 

I am making this PR back again. 