### PR TITLE
A couple thoughts and a small typo fix on 2025-program.md

### DIFF
--- a/docs/iss/2025-program.md
+++ b/docs/iss/2025-program.md
@@ -1111,7 +1111,7 @@
     <div class="table">
         <div class="row">
             <div class="cell"><b>8:30 AM</b></div>
-            <div class="cell">Damien Rouson</div>
+            <div class="cell">Damian Rouson</div>
             <div class="cell-content">
     ??? abstract cell "Cloud microphysics training and aerosol inference with the Fiats deep learning library"
         *Damian Rouson is a Senior Scientist and the Group Lead for the Computer


### PR DESCRIPTION
The program looks good to me except a few thoughts and a small typo with an author's first name that this PR fixes:

* Wednesday's schedule can benefit from an "End of Day" entry, which can help show the networking event is for 2 hours
* Thursday's "Closing Remarks" at 8:30 am does not show up in this program; not sure if it's intentional though
