### PR TITLE
Add guidance regarding paper length

### DIFF
--- a/docs/iss/2026/index.md
+++ b/docs/iss/2026/index.md
@@ -208,7 +208,8 @@ to a conference collection on Zenodo.
 For paper submissions, we ask that authors leverage one of the
 [IEEE manuscript templates for conference proceedings](https://www.ieee.org/conferences/publishing/templates)
 and follow [their guidance on topics such as recycled material and the use of generative AI](https://conferences.ieeeauthorcenter.ieee.org/author-ethics/guidelines-and-policies/submission-policies/).
-Papers will undergo a light, single-blind review process to ensure the content
+Papers should not exceed 6000 words excluding references
+and will undergo a light, single-blind review process to ensure the content
 is technically sound, clearly written, provides appropriate documentation and
 references, and adheres to submission guidelines.
 

--- a/docs/iss/2026/index.md
+++ b/docs/iss/2026/index.md
@@ -208,8 +208,8 @@ to a conference collection on Zenodo.
 For paper submissions, we ask that authors leverage one of the
 [IEEE manuscript templates for conference proceedings](https://www.ieee.org/conferences/publishing/templates)
 and follow [their guidance on topics such as recycled material and the use of generative AI](https://conferences.ieeeauthorcenter.ieee.org/author-ethics/guidelines-and-policies/submission-policies/).
-Papers should not exceed 6000 words excluding references
-and will undergo a light, single-blind review process to ensure the content
+Papers should be roughly 3000-6000 words excluding references.
+Papers will undergo a light, single-blind review process to ensure the content
 is technically sound, clearly written, provides appropriate documentation and
 references, and adheres to submission guidelines.
 


### PR DESCRIPTION
Adds some guidance regarding paper length to the ISS26 proceedings section.

I thought about adding a lower limit as well, but I'm sure how helpful that might be.

The 6000 word limit is based upon prior submissions and general recommendations for conference papers.  If we were to add a lower limit, I'd suggest either 2000 or 3000 words.