### PR TITLE
Add new ISS 2026 agenda post

### DIFF
--- a/docs/posts/20260317-iss26-agenda-online.md
+++ b/docs/posts/20260317-iss26-agenda-online.md
@@ -6,6 +6,7 @@ authors:
 categories:
   - Announcements
   - ISS Conference
+  - Program
 ---
 
 # ISS 2026 program now online.

--- a/docs/posts/20260317-iss26-agenda-online.md
+++ b/docs/posts/20260317-iss26-agenda-online.md
@@ -1,0 +1,16 @@
+---
+draft: false 
+date: 2026-03-17
+authors:
+  - nusbaume
+categories:
+  - Announcements
+  - ISS Conference
+---
+
+# ISS 2026 program now online.
+
+The ISS 2026 agenda is now available!  You can find it [online here](iss/2026/program).
+
+Hope to see you in April at ISS 2026!
+


### PR DESCRIPTION
Adds a new post pointing readers to the ISS 2026 conference agenda web page.