### PR TITLE
Remove Tues. and Wed. office hours from schedule

### DIFF
--- a/docs/iss/2026/program.md
+++ b/docs/iss/2026/program.md
@@ -432,13 +432,6 @@
             <div class="cell"><b>4:00 PM</b></div>
             <div class="cell"></div>
             <div class="cell-content">
-    ??? info cell "Proceedings Office Hours"
-        </div>
-        </div>
-        <div class="row">
-            <div class="cell"><b>4:50 PM</b></div>
-            <div class="cell"></div>
-            <div class="cell-content">
     ??? info cell "end of day"
         </div>
         </div>
@@ -628,13 +621,6 @@
         </div>
         <div class="row">
             <div class="cell"><b>4:00 PM</b></div>
-            <div class="cell"></div>
-            <div class="cell-content">
-    ??? info cell "Proceedings Office Hours"
-        </div>
-        </div>
-        <div class="row">
-            <div class="cell"><b>4:50 PM</b></div>
             <div class="cell"></div>
             <div class="cell-content">
     ??? info cell "end of day"


### PR DESCRIPTION
As suggested by @kafitzgerald, the "Proceedings Office hours" have been removed from the ISS 2026 schedule for Tuesday and Wednesday, as they are likely not needed and there won't be anyone there from the committee to run them.