### PR TITLE
Fix broken links in website posts.

### DIFF
--- a/docs/posts/20260317-iss26-agenda-online.md
+++ b/docs/posts/20260317-iss26-agenda-online.md
@@ -11,7 +11,7 @@ categories:
 
 # ISS 2026 program now online.
 
-The ISS 2026 agenda is now available!  You can find it [online here](iss/2026/program).
+The ISS 2026 agenda is now available!  You can find it [online here](https://sea.ucar.edu/iss/2026/program/).
 
 Hope to see you in April at ISS 2026!
 

--- a/docs/posts/20260317-registration-deadline-reminder.md
+++ b/docs/posts/20260317-registration-deadline-reminder.md
@@ -17,5 +17,5 @@ Inn until March 22nd. Virtual participants may register until April 3rd.
 
 The ISS Conference, hosted by the UCAR Software Engineering Assembly, will be held April 6-9,
 2026 in Boulder CO, with the theme of Maintaining the Joy of Software Development. Visit our
-conference website [conference website](iss/2026) for more information.
+conference website [conference website](https://sea.ucar.edu/iss/) for more information.
 


### PR DESCRIPTION
The previous two website links included in announcement posts were broken for some reason, so replacing with the full URL.