### PR TITLE
Fix links and turn on corresponding warnings

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -10,7 +10,7 @@ dependencies:
     - click<8.3.0
     - jinja2>=3.0
     - markdown>=3.2
-    - mkdocs>=1.4.2
+    - mkdocs>=1.6.0
     - mkdocs-material-extensions>=1.1
     - pygments>=2.14
     - pymdown-extensions>=9.9.1

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -4,7 +4,7 @@ If you want to become involved in the SEA, there are many ways to join our commu
 
 1. Our primary communication platforms are our [Slack workspace](https://ucarsea.slack.com) (new users can sign up with [this invite link](https://join.slack.com/t/ucarsea/shared_invite/zt-3by28gvzo-3mZEGXB3giPLRllyGaDPZQ)) and [mailing list](listserv.md).
 2. You can also participate directly by joining our [Steering Committee](../about/index.md#steering-committee) or our [ISS Planning Committee](../iss/index.md).
-3. If there is a specific topic you are passionate about, you can volunteer to lead an [Open Discussion](../discussions/index.md).
+3. If there is a specific topic you are passionate about, you can volunteer to lead an [Open Discussion](../events/discussions.md).
 
 And of course, we are always open to new ideas for SEA activities.
 

--- a/docs/events/seminars.md
+++ b/docs/events/seminars.md
@@ -8,7 +8,7 @@ in-person seminars in Boulder, CO as well if there is a clear benefit.
 
 If you wish to give a seminar, or have a topic or speaker in mind and want us to
 facilitate an event, reach out to the [SEA Steering
-Committee](sea_committee@ucar.edu) with a description of your vision for the
+Committee](mailto:sea_committee@ucar.edu) with a description of your vision for the
 seminar.
 
 ## Seminar Archive

--- a/docs/posts/20250218-iss2025-registration-open.md
+++ b/docs/posts/20250218-iss2025-registration-open.md
@@ -13,7 +13,7 @@ categories:
 
 The Improving Scientific Software (ISS) Conference committee is pleased to
 announce that registration is now open for our [2025
-Conference](../iss/2025.md), taking place April 7-10 in Boulder, Colorado. ISS
+Conference](../iss/2025/index.md), taking place April 7-10 in Boulder, Colorado. ISS
 brings together software engineers, scientists, developers - any individuals
 with an interest in scientific software design - to share novel experiences and
 best practices, develop connections across divisions and institutions, and
@@ -22,4 +22,4 @@ advance our community.
 Participants may register either for in-person or virtual attendance. In-person
 registration will close on March 21st, while virtual registration will close on
 April 3rd. For more information and the link to the registration page, see [the
-ISS 2025 Conference website](../iss/2025.md).
+ISS 2025 Conference website](../iss/2025/index.md).

--- a/docs/posts/20250312-iss2025-program.md
+++ b/docs/posts/20250312-iss2025-program.md
@@ -12,7 +12,7 @@ categories:
 
 # ISS 2025: Program and registration are available now
 
-The [online program](iss/2025/program/) is now available for the 2025 Improving
+The [online program](../iss/2025/program.md) is now available for the 2025 Improving
 Scientific Software Conference. Our 4-day program includes a number of talks and
 two tutorials, along with two keynote presentations (details to be announced
 soon). We would like to thank all who submitted an abstract to this year's
@@ -24,4 +24,4 @@ Friday, March 21, so make sure you register soon if you plan to join us in
 Boulder. Virtual registration will close on April 3. We have also extended the
 reduced-rate conference hotel booking deadline to March 19th. For more
 information along with the link to the registration portal, visit the [ISS 2025
-website](iss/2025/).
+website](../iss/2025/index.md).

--- a/docs/posts/20250324-iss2025-reg-update.md
+++ b/docs/posts/20250324-iss2025-reg-update.md
@@ -18,7 +18,7 @@ month; we look forward to seeing you! If you have not yet registered but would
 still like to attend, *virtual* registration will remain open until the end of
 the day on April 3rd.
 
-See our [ISS 2025 Conference Site](iss/2025/) for more
+See our [ISS 2025 Conference Site](../iss/2025/index.md) for more
 information about registration and our [virtual conference
-program](iss/2025/program/) for a listing of all planned
+program](../iss/2025/program.md) for a listing of all planned
 talks, tutorials, and events.

--- a/docs/posts/20250428-iss2025-retro.md
+++ b/docs/posts/20250428-iss2025-retro.md
@@ -13,7 +13,7 @@ categories:
 # ISS 2025 Slides, Recordings, and Post-Conference Survey
 
 The [2025 Improving Scientific Software
-Conference](https://sea.ucar.edu/iss/2025/) Committee would like to thank all
+Conference](../iss/2025/index.md) Committee would like to thank all
 presenters and attendees for making this year's Conference a success. We were
 happy to see valuable contributions from many different institutions and areas
 of study, as well as good discussion during the networking events and socials.
@@ -23,5 +23,5 @@ provide us with feedback.
 
 We have also posted the slides and recordings from each presentation and
 tutorial on the [Online Conference
-Program](https://sea.ucar.edu/iss/2025-program/). These materials are available
+Program](../iss/2025/program.md). These materials are available
 to all.

--- a/docs/posts/20250922-iss2025-proceedings-published.md
+++ b/docs/posts/20250922-iss2025-proceedings-published.md
@@ -13,7 +13,7 @@ categories:
 The 2025 Improving Scientific Software Proceedings Committee is excited to
 present the cumulative efforts of the many authors who wrote and submitted a
 paper to our Conference Proceedings - which are now accessible via the [ISS 2025
-Proceedings Gallery](iss/2025/proceedings/).
+Proceedings Gallery](../iss/2025/proceedings.md).
 
 This year, we decided to experiment with using Jupyter Notebooks as the paper
 format instead of plain-text papers, allowing for greater expressiveness and the

--- a/docs/posts/20251006-seminar-archive.md
+++ b/docs/posts/20251006-seminar-archive.md
@@ -19,6 +19,6 @@ opportunities to evaluate the platform with your code base, [contact
 us](mailto:sea_committee@ucar.edu) and we can faciliate further conversation.
 
 This seminar, and future SEA seminars, will be made available on the [SEA Seminar
-archive](events/seminars). Stay tuned for future SEA seminar announcements,
+archive](../events/seminars.md). Stay tuned for future SEA seminar announcements,
 and please reach out to the [SEA Steering
 Committee](mailto:sea_committee@ucar.edu) if you have ideas for future seminars.

--- a/docs/posts/20251120-iss-2026-abstracts.md
+++ b/docs/posts/20251120-iss-2026-abstracts.md
@@ -12,7 +12,7 @@ categories:
 # 2026 Improving Scientific Software Conference now accepting abstracts
 
 The UCAR Software Engineering Assembly's [Improving Scientific Software
-Conference](iss/) is returning in 2026! Next year's ISS will take place April
+Conference](../iss/index.md) is returning in 2026! Next year's ISS will take place April
 6-10, 2026 at NSF NCAR's Mesa Laboratory in Boulder, CO. The theme of the
 conference will be:
 
@@ -24,5 +24,5 @@ software design, quality, development, deployment, and support. **Abstracts are
 due by: Friday January 23, 2026.** We plan to provide student support as funding
 allows and will accept paper submissions for a conference proceeding.
 
-You may submit an abstract [here](iss/2026/#submitting-an-abstract) and visit
-our [conference website](iss/2026) for more information.
+You may submit an abstract [here](../iss/2026/index.md#submitting-an-abstract) and visit
+our [conference website](../iss/2026/index.md) for more information.

--- a/docs/posts/20251229-iss-2026-abstract-reminder.md
+++ b/docs/posts/20251229-iss-2026-abstract-reminder.md
@@ -11,11 +11,11 @@ categories:
 
 # Reminder: Improving Scientific Software Conference Accepting Abstracts
 
-The [2026 Improving Scientific Software Conference](iss/2026) is accepting
+The [2026 Improving Scientific Software Conference](../iss/2026/index.md) is accepting
 abstracts through January 23, 2026. The conference is planned for April 6-10,
 2026 at NSF NCAR's Mesa Laboratory in Boulder, CO with the theme being
 *Maintaining the Joy of Software Development*. We are [accepting abstract
-submissions](iss/2026/#submitting-an-abstract) for talks, tutorials, and panel
+submissions](../iss/2026/index.md#submitting-an-abstract) for talks, tutorials, and panel
 sessions, and presenters may attend either in person or virtually.
 
 You have likely seen news coverage last week that the National Science

--- a/docs/posts/20260122-iss-2026-extension-venue.md
+++ b/docs/posts/20260122-iss-2026-extension-venue.md
@@ -12,7 +12,7 @@ categories:
 # ISS 2026 Abstract Deadline is Now January 30th
 
 The deadline is fast approaching to submit abstracts to the 2026 [Improving
-Scientific Software Conference](iss). The ISS Conference will be held April
+Scientific Software Conference](../iss/index.md). The ISS Conference will be held April
 6-10, 2026 in Boulder, CO with the theme of *Maintaining the Joy of Software
 Development*.
 
@@ -29,5 +29,5 @@ facilities construction timeline changes, this venue is once again available to
 us and offers easier logistics for conference attendees. The conference will be
 hybrid, so virtual presentations are also welcome.
 
-You may submit an abstract [here](iss/2026/#submitting-an-abstract) and visit
-our [conference website](iss/2026) for more information.
+You may submit an abstract [here](../iss/2026/index.md#submitting-an-abstract) and visit
+our [conference website](../iss/2026/index.md) for more information.

--- a/docs/posts/20260217-pfunit-recording.md
+++ b/docs/posts/20260217-pfunit-recording.md
@@ -18,7 +18,7 @@ notes](https://docs.google.com/document/d/1ZqB4E1Zu7Gkv8_6VkLLpnAfrYbcOqw8d4XpWd
 from the event have also been uploaded.
 
 You can find links to all notes and recordings in our [Open Discussions
-page](events/discussions). We're currently planning the next discussion for
+page](../events/discussions.md). We're currently planning the next discussion for
 early March - stay tuned for an announcement (topic hint: using LLMs in coding)!
 
 As always, if you would like to suggest a Discussion topic, or volunteer to lead

--- a/docs/posts/20260218-iss2026-registration-open.md
+++ b/docs/posts/20260218-iss2026-registration-open.md
@@ -12,7 +12,7 @@ categories:
 # Register now to attend the 2026 Improving Scientific Software Conference!
 
 Registration is now open for the [2026 Improving Scientific Software
-Conference](iss/2026). The ISS Conference, hosted by the UCAR Software
+Conference](../iss/2026/index.md). The ISS Conference, hosted by the UCAR Software
 Engineering Assembly, will be held April 6-9, 2026 in Boulder, CO with the theme
 of *Maintaining the Joy of Software Development*.
 
@@ -22,4 +22,4 @@ software topics. The deadline to register is March 20th, 2026 if you are
 attending in person, and April 3rd, 2026 for the virtual option. We will also
 offer block-rate hotel lodging at the walking-distance Residence Inn Boulder.
 
-Visit our [conference website](iss/2026) for more information.
+Visit our [conference website](../iss/2026/index.md) for more information.

--- a/docs/posts/20260219-iss2026-lodging.md
+++ b/docs/posts/20260219-iss2026-lodging.md
@@ -12,7 +12,7 @@ categories:
 
 A quick addendum to yesterday's announcement - we are now able to offer our
 block-rate lodging for the [2026 Improving Scientific Software
-Conference](iss/2026).
+Conference](../iss/2026/index.md).
 
 As in prior years, the walking-distance [Residence Inn
 Boulder](https://www.marriott.com/en-us/hotels/vbocg-residence-inn-boulder/overview/?scid=f2ae0541-1279-4f24-b197-a979c79310b0)
@@ -22,4 +22,4 @@ the end of the conference (Thursday, April 9) if you wish to spend time
 exploring Boulder. The last day to book using the block rate is  **Sunday, March
 8, 2026!**
 
-See our [conference website](iss/2026) for a link to the booking portal.
+See our [conference website](../iss/2026/index.md) for a link to the booking portal.

--- a/docs/posts/20260309-iss-2026-hotel-extension.md
+++ b/docs/posts/20260309-iss-2026-hotel-extension.md
@@ -15,4 +15,4 @@ Boulder](https://www.marriott.com/en-us/hotels/vbocg-residence-inn-boulder/overv
 has been extended to **Sunday, March 22, 2026**, so if you missed the
 original deadline you now have another chance to book.
 
-See our [conference website](iss/2026) for a link to the booking portal.
+See our [conference website](../iss/2026/index.md) for a link to the booking portal.

--- a/docs/posts/20260312-vibecoder-recording.md
+++ b/docs/posts/20260312-vibecoder-recording.md
@@ -18,8 +18,8 @@ notes](https://docs.google.com/document/d/14JhCesbYJI6eNoCaw_KjMOK9mDBs5g0ZNJqxE
 from the event have also been uploaded.
 
 You can find links to all notes and recordings in our [Open Discussions
-page](events/discussions). As the yearly [Improving Scientific Software
-Conference](iss/2026) will take place in early April, we will not have an SEA
+page](../events/discussions.md). As the yearly [Improving Scientific Software
+Conference](../iss/2026/index.md) will take place in early April, we will not have an SEA
 event, but stay tuned for future announcements after ISS.
 
 If you would like to suggest a Discussion topic, or volunteer to lead a

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,13 +21,14 @@ watch:
 validation:
   nav:
     not_found: warn             # check if stubs exist or not!
-    omitted_files: ignore       # check for files that exist without any links to them in nav
+    omitted_files: warn         # check for files that exist without any links to them in nav
     absolute_links : warn       # check for absolute links -- pointers to outside htmls in nav
+    anchors: warn
 
   links:
-    not_found: ignore           # check for broken links inside mds. (to be activated later!)
-    absolute_links : ignore     # check for absolute links -- pointers to outside htmls in files (to be activated later!)
-    unrecognized_links: ignore  # unrecognized relative links (to be activated later!)
+    not_found: warn             # check for broken links inside mds. (to be activated later!)
+    absolute_links : warn       # check for absolute links -- pointers to outside htmls in files (to be activated later!)
+    unrecognized_links: warn    # unrecognized relative links (to be activated later!)
 
 # ------------------------------------
 # ----------- content ----------------

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,12 +23,12 @@ validation:
     not_found: warn             # check if stubs exist or not!
     omitted_files: warn         # check for files that exist without any links to them in nav
     absolute_links : warn       # check for absolute links -- pointers to outside htmls in nav
-    anchors: warn
 
   links:
     not_found: warn             # check for broken links inside mds. (to be activated later!)
     absolute_links : warn       # check for absolute links -- pointers to outside htmls in files (to be activated later!)
     unrecognized_links: warn    # unrecognized relative links (to be activated later!)
+    anchors: warn
 
 # ------------------------------------
 # ----------- content ----------------


### PR DESCRIPTION
Fixes several links and turns on warnings for link and nav issues in MkDocs config.

We could drop the MkDocs min version bump if we wanted to drop a couple of the warnings, but I don't imagine this should be an issue.

Closes #28.