### PR TITLE
Add ISS26 proceedings page

### DIFF
--- a/docs/iss/2026/proceedings.md
+++ b/docs/iss/2026/proceedings.md
@@ -1,0 +1,15 @@
+<style>
+.md-typeset div.grid.cards {
+    grid-template-columns: 1fr;
+}
+</style>
+
+<figure markdown="span">
+    <img src="../../assets/iss2026.png" alt="drawing" width="70%"/>
+    <figcaption>**Maintaining the Joy of Software Development**</figcaption>
+</figure>
+
+# Conference Proceedings
+
+The conference proceedings are hosted in the [ISS26 community on Zenodo](https://zenodo.org/communities/iss26).
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - 2026:
       - Conference: iss/2026/index.md
       - Program: iss/2026/program.md
+      - Proceedings: iss/2026/proceedings.md
     - 2025: 
       - Conference: iss/2025/index.md
       - Program: iss/2025/program.md


### PR DESCRIPTION
Adds a minimal page for the ISS26 conference proceedings pointing to the conference Zenodo community.

We should be able to add the NCAR Tech Note to the community as well once that's available and/or add a note on this page as well.

Closes #42 