### PR TITLE
Fix image path for the 2026 proceedings page

### DIFF
--- a/docs/iss/2026/proceedings.md
+++ b/docs/iss/2026/proceedings.md
@@ -5,7 +5,7 @@
 </style>
 
 <figure markdown="span">
-    <img src="../../assets/iss2026.png" alt="drawing" width="70%"/>
+    <img src="../../../assets/iss2026.png" alt="drawing" width="80%"/>
     <figcaption>**Maintaining the Joy of Software Development**</figcaption>
 </figure>
 


### PR DESCRIPTION
Just noticed this was broken.  Not sure how I missed it the first time around.